### PR TITLE
feat: PC 화면에서는 더 보기 버튼, 모바일은 무한 스크롤 유지

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ pip install -r requirements-dev.txt
 - 순수 HTML/CSS/JS, 빌드 도구 없음. Firebase JS SDK는 `js/app.js`에서 gstatic CDN의 ES 모듈을 직접 import.
 - `js/firebase-config.js`의 `firebaseConfig`는 공개 저장소에 그대로 커밋되어 있음 — Firestore 보안 규칙(`allow read: if true; allow write: if false;`)이 실제 접근 제어를 담당하므로 의도된 것. `appId`는 별도 웹앱을 등록하지 않아 iOS 앱의 값을 재사용 중(Firestore 읽기엔 문제없음).
 - `js/app.js`가 iOS `MainView.groupPostsByDate` / `PostManager` 로직을 그대로 재현: `date` 내림차순 + 커서 페이지네이션, 오늘/어제 글은 "최신" 섹션, 나머지는 월별 섹션, `blog_name === "Aws"` 제외.
-- 페이지네이션은 iOS의 `LastListLoadingView().onAppear`와 동일하게 `#scroll-sentinel`을 관찰하는 `IntersectionObserver` 기반 무한 스크롤(수동 "더 보기" 버튼 없음).
+- 페이지네이션은 화면 폭에 따라 분기: 좁은 화면(모바일, `(min-width: 700px)` 미만)은 iOS의 `LastListLoadingView().onAppear`와 동일하게 `#scroll-sentinel`을 관찰하는 `IntersectionObserver` 기반 무한 스크롤, 넓은 화면(PC)은 `#load-more` 버튼을 눌러야 다음 페이지를 가져오는 수동 방식. `window.matchMedia` 변경 이벤트로 화면 폭이 바뀌면 버튼 표시 여부를 다시 계산.
 - 북마크는 Firestore 쓰기가 막혀 있어(`allow write: if false`) `localStorage`(`tbn-bookmarks` 키, 단일 배열)에만 저장 — iOS의 `UserDefaults` 두 저장소(ID 목록 + 스냅샷) 분리는 웹의 단일 `setItem` 쓰기에는 불필요해 하나로 단순화. iOS는 상세 화면 툴바에서 북마크를 토글하지만, 웹은 상세 화면 없이 각 행이 바로 외부 링크로 연결되므로 북마크 별 아이콘이 리스트 행(`.post-bookmark`) 위에 직접 있고, nav-bar의 `#bookmark-filter` 토글로 북마크만 모아 볼 수 있다.
 
 ## 커밋 컨벤션

--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -181,6 +181,7 @@ main {
 }
 
 .loading-state[hidden],
+.load-more[hidden],
 .empty-state[hidden],
 .error-state[hidden] {
   display: none;
@@ -205,5 +206,23 @@ main {
   color: var(--secondary-label);
   font-size: 15px;
   padding: 40px 16px;
+}
+
+.load-more {
+  display: block;
+  width: 100%;
+  margin-top: 8px;
+  padding: 12px;
+  border: none;
+  border-radius: 10px;
+  background: var(--card-bg);
+  color: var(--tint);
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.load-more:active {
+  background: var(--separator);
 }
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -27,6 +27,7 @@
     </div>
 
     <div id="scroll-sentinel" aria-hidden="true"></div>
+    <button id="load-more" class="load-more" type="button" hidden>더 보기</button>
   </main>
 
   <script type="module" src="js/app.js"></script>

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -15,6 +15,8 @@ const RECENT_LABEL = "최신";
 const RECENT_DAY_THRESHOLD = 1;
 const EXCLUDED_BLOG_NAMES = new Set(["Aws"]);
 const BOOKMARKS_KEY = "tbn-bookmarks";
+// 모바일은 스크롤 시 자동 로딩, 화면이 넓은 PC에서는 "더 보기" 버튼으로 직접 로딩.
+const desktopMql = window.matchMedia("(min-width: 700px)");
 
 const app = initializeApp(firebaseConfig);
 const db = getFirestore(app);
@@ -23,6 +25,7 @@ const postsRef = collection(db, "posts");
 const sectionsEl = document.getElementById("sections");
 const loadingEl = document.getElementById("loading");
 const sentinelEl = document.getElementById("scroll-sentinel");
+const loadMoreBtn = document.getElementById("load-more");
 const emptyStateEl = document.getElementById("empty-state");
 const errorStateEl = document.getElementById("error-state");
 const bookmarkFilterBtn = document.getElementById("bookmark-filter");
@@ -224,6 +227,12 @@ function renderPost(post) {
 
 function setLoading(isLoading) {
   loadingEl.hidden = !isLoading;
+  if (isLoading) loadMoreBtn.hidden = true;
+}
+
+// PC 화면에서만 "더 보기" 버튼을 보여준다. 모바일은 스크롤 자동 로딩만 사용.
+function refreshLoadMoreUI() {
+  loadMoreBtn.hidden = viewMode !== "all" || !desktopMql.matches || !hasMore;
 }
 
 async function fetchNextPage() {
@@ -268,6 +277,7 @@ async function fetchNextPage() {
   } finally {
     isFetching = false;
     setLoading(false);
+    refreshLoadMoreUI();
   }
 }
 
@@ -282,11 +292,13 @@ function applyAllPostsView() {
   clearSections();
   loadedPosts.forEach(renderPost);
   emptyStateEl.hidden = loadedPosts.length > 0;
+  refreshLoadMoreUI();
 }
 
 function applyBookmarksView() {
   loadingEl.hidden = true;
   errorStateEl.hidden = true;
+  loadMoreBtn.hidden = true;
   emptyStateEl.textContent = "북마크된 게시글이 없습니다.";
   clearSections();
   const list = getBookmarks();
@@ -307,9 +319,16 @@ bookmarkFilterBtn.addEventListener("click", () => {
   setViewMode(viewMode === "all" ? "bookmarks" : "all");
 });
 
+loadMoreBtn.addEventListener("click", () => {
+  if (isFetching || !hasMore) return;
+  fetchNextPage();
+});
+
+desktopMql.addEventListener("change", refreshLoadMoreUI);
+
 const scrollObserver = new IntersectionObserver(
   (entries) => {
-    if (viewMode !== "all") return;
+    if (viewMode !== "all" || desktopMql.matches) return;
     if (!entries[0].isIntersecting) return;
     if (!errorStateEl.hidden) return;
     if (!hasMore || isFetching) return;


### PR DESCRIPTION
넓은 화면에서 IntersectionObserver 자동 로딩이 스크롤 한 번에 전체 글을 다 불러와버려 상호작용할 거리가 없다는 피드백을 반영. matchMedia로 화면
폭을 감지해 PC(min-width: 700px)에서는 "더 보기" 버튼을 다시 노출하고, 모바일은 기존 스크롤 자동 로딩을 그대로 유지.