### PR TITLE
fix: 일부 블로그 파비콘이 안 보이는 문제 수정

### DIFF
--- a/TechBlogNotifications/TechBlogNotifications/View/FavIcon.swift
+++ b/TechBlogNotifications/TechBlogNotifications/View/FavIcon.swift
@@ -27,11 +27,12 @@ struct FavIcon {
     // 실패를 감지할 수 없다(예: d2.naver.com은 자체 파비콘이 멀쩡한데도 이 문제로 안 보임). 반면
     // 사이트 자체 favicon.ico는 없거나 깨졌을 때 진짜 실패로 이어지므로, 도메인 자체 favicon.ico를
     // 먼저 시도하고 실패할 때만 Google로 폴백한다.
+    // override가 있어도 맨 앞 순위로만 두고 나머지 후보를 함께 반환한다 — override URL이 나중에
+    // 깨지거나 옮겨져도 완전히 빈 아이콘이 되지 않고 도메인/Google 순으로 계속 폴백하도록.
     func candidates(blogName: String, size: Size) -> [URL] {
-        if let override = FavIcon.overrides[blogName], let url = URL(string: override) {
-            return [url]
-        }
+        let overrideUrl = FavIcon.overrides[blogName].flatMap { URL(string: $0) }
         return [
+            overrideUrl,
             URL(string: "\(domain)/favicon.ico"),
             URL(string: googleUrl(size)),
         ].compactMap { $0 }

--- a/TechBlogNotifications/TechBlogNotifications/View/FavIcon.swift
+++ b/TechBlogNotifications/TechBlogNotifications/View/FavIcon.swift
@@ -9,9 +9,31 @@ import Foundation
 
 struct FavIcon {
     enum Size: Int, CaseIterable { case s = 16, m = 32, l = 64, xl = 128, xxl = 256, xxxl = 512 }
+
+    // techblog.samsung.com처럼 자체 파비콘 자체가 깨져 있어 도메인 기반으로는 찾을 수 없는
+    // 블로그를 위한 수동 예외. blog_name 기준(회사 공식 사이트 아이콘 등으로 직접 지정).
+    private static let overrides: [String: String] = [
+        "Samsung": "https://www.samsung.com/sec/static/_images/favicon.ico",
+    ]
+
     private let domain: String
     init(_ domain: String) { self.domain = domain }
-    subscript(_ size: Size) -> String {
+
+    private func googleUrl(_ size: Size) -> String {
         "https://www.google.com/s2/favicons?sz=\(size.rawValue)&domain=\(domain)"
+    }
+
+    // Google의 favicon 서비스는 못 찾은 도메인에도 (404 상태이지만) 유효한 기본 이미지를 돌려줘서
+    // 실패를 감지할 수 없다(예: d2.naver.com은 자체 파비콘이 멀쩡한데도 이 문제로 안 보임). 반면
+    // 사이트 자체 favicon.ico는 없거나 깨졌을 때 진짜 실패로 이어지므로, 도메인 자체 favicon.ico를
+    // 먼저 시도하고 실패할 때만 Google로 폴백한다.
+    func candidates(blogName: String, size: Size) -> [URL] {
+        if let override = FavIcon.overrides[blogName], let url = URL(string: override) {
+            return [url]
+        }
+        return [
+            URL(string: "\(domain)/favicon.ico"),
+            URL(string: googleUrl(size)),
+        ].compactMap { $0 }
     }
 }

--- a/TechBlogNotifications/TechBlogNotifications/View/PostRowView.swift
+++ b/TechBlogNotifications/TechBlogNotifications/View/PostRowView.swift
@@ -20,7 +20,7 @@ struct PostRowView: View {
                     .font(.headline)
                     .fontWeight(.bold)
                 HStack {
-                    CachedAsyncImage(url: URL(string: FavIcon(post.baseUrl)[.l]))
+                    CachedAsyncImage(urls: FavIcon(post.baseUrl).candidates(blogName: post.blogName, size: .l))
                         .frame(width: 16, height: 16)
                     Text("\(post.blogName)")
                         .font(.subheadline)
@@ -56,10 +56,10 @@ struct PostDetailView: View {
 }
 
 struct CachedAsyncImage: View {
-    let url: URL?
+    let urls: [URL]
     @State private var uiImage: UIImage? = nil
     @State private var isLoading = false
-    
+
     var body: some View {
         Group {
             if let uiImage = uiImage {
@@ -76,13 +76,17 @@ struct CachedAsyncImage: View {
             }
         }
         .onAppear {
-            loadImage()
+            loadImage(candidateIndex: 0)
         }
     }
-    
-    private func loadImage() {
-        guard let url = url else { return }
-        
+
+    // 후보 URL을 순서대로 시도한다. Google favicon 서비스는 못 찾은 도메인에도 (404 상태이지만)
+    // 유효한 기본 이미지를 돌려주므로, 디코딩 성공 여부만으로는 실패를 감지할 수 없다. 그래서
+    // HTTP 상태 코드까지 확인해 진짜 실패일 때만 다음 후보로 넘어간다.
+    private func loadImage(candidateIndex: Int) {
+        guard candidateIndex < urls.count else { return }
+        let url = urls[candidateIndex]
+
         // URLCache를 통한 캐싱된 데이터 확인
         if let cachedResponse = URLCache.shared.cachedResponse(for: URLRequest(url: url)),
            let cachedImage = UIImage(data: cachedResponse.data) {
@@ -91,7 +95,7 @@ struct CachedAsyncImage: View {
             }
             return
         }
-        
+
         // 네트워크 요청 시작
         isLoading = true
         URLSession.shared.dataTask(with: url) { data, response, error in
@@ -100,19 +104,21 @@ struct CachedAsyncImage: View {
                     self.isLoading = false
                 }
             }
-                        
-            guard let data = data, let response = response, error == nil,
+
+            guard let data = data, error == nil,
+                  let httpResponse = response as? HTTPURLResponse,
+                  (200...299).contains(httpResponse.statusCode),
                   let image = UIImage(data: data) else {
+                DispatchQueue.main.async {
+                    self.loadImage(candidateIndex: candidateIndex + 1)
+                }
                 return
             }
-            
+
             // 캐시 저장
-            if let response = response as? HTTPURLResponse,
-               (200...299).contains(response.statusCode) {
-                let cachedData = CachedURLResponse(response: response, data: data)
-                URLCache.shared.storeCachedResponse(cachedData, for: URLRequest(url: url))
-            }
-            
+            let cachedData = CachedURLResponse(response: httpResponse, data: data)
+            URLCache.shared.storeCachedResponse(cachedData, for: URLRequest(url: url))
+
             // UI 업데이트
             DispatchQueue.main.async {
                 self.uiImage = image

--- a/TechBlogNotifications/TechBlogNotifications/View/PostRowView.swift
+++ b/TechBlogNotifications/TechBlogNotifications/View/PostRowView.swift
@@ -87,8 +87,12 @@ struct CachedAsyncImage: View {
         guard candidateIndex < urls.count else { return }
         let url = urls[candidateIndex]
 
-        // URLCache를 통한 캐싱된 데이터 확인
+        // URLCache를 통한 캐싱된 데이터 확인. URLSession이 서버 캐시 헤더에 따라 404 응답도
+        // 자동으로 캐싱해둘 수 있으므로(Google favicon 서비스의 기본 이미지 응답 등), 캐시
+        // 히트 시에도 상태 코드를 검증해야 잘못된 기본 아이콘이 그대로 쓰이는 걸 막을 수 있다.
         if let cachedResponse = URLCache.shared.cachedResponse(for: URLRequest(url: url)),
+           let httpResponse = cachedResponse.response as? HTTPURLResponse,
+           (200...299).contains(httpResponse.statusCode),
            let cachedImage = UIImage(data: cachedResponse.data) {
             DispatchQueue.main.async {
                 self.uiImage = cachedImage


### PR DESCRIPTION
## Summary
- Google favicon 서비스(`s2/favicons`)는 못 찾은 도메인에도 (404 상태이지만) 유효한 기본 이미지를 돌려줘서 실패를 감지할 수 없었음 — `d2.naver.com`은 자체 파비콘이 멀쩡한데도 이 문제로 안 보였음
- `CachedAsyncImage`가 사이트 자체 도메인의 `favicon.ico`를 먼저 시도하고, HTTP 상태 코드까지 확인해 실패할 때만 Google 서비스로 폴백하도록 수정
- `techblog.samsung.com`처럼 자체 파비콘 자체가 깨져 있어 도메인 기반으로는 찾을 수 없는 블로그는 `FavIcon.overrides`에 `blog_name` 기준 수동 예외(삼성 공식 사이트 아이콘)로 처리
- 웹(`docs/js/app.js`)에도 동일한 원인/해결 방식을 별도 PR #130에 반영함

## Test plan
- [ ] Xcode에서 빌드 후 시뮬레이터/기기로 확인 (이 세션에서는 Xcode를 사용할 수 없어 직접 검증 못 함 — 웹 쪽(`docs/js/app.js`)에서는 동일 로직을 Playwright로 검증 완료)
  - Naver D2, Samsung 게시글 행에 정상적인 파비콘이 뜨는지
  - Kakao, Toss 등 기존에 잘 뜨던 블로그가 계속 정상 동작하는지

🤖 Generated with [Claude Code](https://claude.com/claude-code)