### PR TITLE
feat: 웹 북마크 아이콘을 별 대신 북마크 모양으로 변경

### DIFF
--- a/docs/css/style.css
+++ b/docs/css/style.css
@@ -60,17 +60,23 @@ html, body {
 }
 
 .bookmark-filter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   border: none;
   background: none;
   padding: 4px;
-  font-size: 20px;
-  line-height: 1;
   color: var(--secondary-label);
   cursor: pointer;
 }
 
 .bookmark-filter.active {
   color: var(--tint);
+}
+
+.bookmark-filter svg,
+.post-bookmark svg {
+  display: block;
 }
 
 main {

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,11 @@
   <header class="nav-bar">
     <h1 class="nav-title">기술 블로그 모음</h1>
     <button id="bookmark-filter" class="bookmark-filter" type="button"
-            aria-pressed="false" aria-label="북마크만 보기">☆</button>
+            aria-pressed="false" aria-label="북마크만 보기">
+      <svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">
+        <path d="M6 3a2 2 0 0 0-2 2v16l8-5 8 5V5a2 2 0 0 0-2-2H6z" fill="none" stroke="currentColor" stroke-width="2" stroke-linejoin="round"/>
+      </svg>
+    </button>
   </header>
 
   <main id="content">

--- a/docs/js/app.js
+++ b/docs/js/app.js
@@ -15,6 +15,12 @@ const RECENT_LABEL = "최신";
 const RECENT_DAY_THRESHOLD = 1;
 const EXCLUDED_BLOG_NAMES = new Set(["Aws"]);
 const BOOKMARKS_KEY = "tbn-bookmarks";
+const BOOKMARK_ICON_PATH = "M6 3a2 2 0 0 0-2 2v16l8-5 8 5V5a2 2 0 0 0-2-2H6z";
+function bookmarkIconSvg(active) {
+  return `<svg viewBox="0 0 24 24" width="18" height="18" aria-hidden="true">` +
+    `<path d="${BOOKMARK_ICON_PATH}" fill="${active ? "currentColor" : "none"}" ` +
+    `stroke="currentColor" stroke-width="2" stroke-linejoin="round"/></svg>`;
+}
 // 스크롤 자동 로딩은 화면 크기와 무관하게 항상 켜져 있고, 화면이 넓은 PC에서는
 // "더 보기" 버튼도 함께 노출해 자동 로딩이 실패했을 때 수동으로 재시도할 수 있게 한다.
 const desktopMql = window.matchMedia("(min-width: 700px)");
@@ -230,7 +236,7 @@ function renderPost(post) {
   star.setAttribute("aria-label", "북마크");
   const setStarVisual = (active) => {
     star.classList.toggle("is-active", active);
-    star.textContent = active ? "★" : "☆";
+    star.innerHTML = bookmarkIconSvg(active);
     star.setAttribute("aria-pressed", String(active));
   };
   setStarVisual(isBookmarked(post.id));
@@ -344,7 +350,7 @@ function setViewMode(mode) {
   if (mode === viewMode) return;
   viewMode = mode;
   bookmarkFilterBtn.classList.toggle("active", mode === "bookmarks");
-  bookmarkFilterBtn.textContent = mode === "bookmarks" ? "★" : "☆";
+  bookmarkFilterBtn.innerHTML = bookmarkIconSvg(mode === "bookmarks");
   bookmarkFilterBtn.setAttribute("aria-pressed", String(mode === "bookmarks"));
   mode === "bookmarks" ? applyBookmarksView() : applyAllPostsView();
 }


### PR DESCRIPTION
## Summary
- 웹페이지의 북마크 토글 아이콘(☆/★)을 SVG 북마크(리본) 모양으로 교체
- 게시글 행의 북마크 버튼, nav-bar 필터 버튼 모두 동일 아이콘 적용, 활성 상태는 채움(fill)으로 구분

## Test plan
- [ ] 로컬 정적 서버로 `docs/index.html` 열어 게시글 행 북마크 토글 클릭 시 아이콘 채워짐/비워짐 확인
- [ ] nav-bar 북마크 필터 버튼 토글 시 아이콘 및 필터링 정상 동작 확인
- [ ] 다크모드에서 아이콘 색상(tint) 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)